### PR TITLE
GTSAM viz for multi-trajectory and multi-landmark information

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,8 +1,11 @@
 add_executable(SimpleCheckout SimpleCheckout.cpp)
 target_link_libraries(SimpleCheckout tonioviz)
 
-add_executable(GtsamExample GtsamExample.cpp)
-target_link_libraries(GtsamExample tonioviz)
+add_executable(GtsamExample1 GtsamExample1.cpp)
+target_link_libraries(GtsamExample1 tonioviz)
+
+add_executable(GtsamExample2 GtsamExample2.cpp)
+target_link_libraries(GtsamExample2 tonioviz)
 
 add_executable(MultiTrajectoryExample MultiTrajectoryExample.cpp)
 target_link_libraries(MultiTrajectoryExample tonioviz)

--- a/examples/GtsamExample1.cpp
+++ b/examples/GtsamExample1.cpp
@@ -1,7 +1,8 @@
 /**
- * @file SimpleCheckout.cpp
- * @brief Quick GTSAM visualization test.
+ * @file GtsamExample1.cpp
+ * @brief Quick GTSAM visualization test to check use of poses from GTSAM
  * @author Tonio Teran, teran@mit.edu
+ * @author Alan Papalia, apapalia@mit.edu
  * Copyright 2020 The Ambitious Folks of the MRG
  */
 
@@ -10,12 +11,10 @@
 #include <fstream>
 #include <iostream>
 // NOLINTNEXTLINE
-#include <thread>
-
 #include <gtsam/geometry/Pose3.h>
 #include <gtsam/inference/Symbol.h>
-#include <gtsam/inference/Symbol.h>
 
+#include <thread>
 
 #include "tonioviz/GtsamUtils.h"
 #include "tonioviz/Visualizer.h"

--- a/examples/GtsamExample2.cpp
+++ b/examples/GtsamExample2.cpp
@@ -1,0 +1,199 @@
+/**
+ * @file GtsamExample2.cpp
+ * @brief Slightly more advanced GTSAM visualization test to check automatic
+ * visualization given values and symbols for landmarks and pose chains
+ * @author Alan Papalia, apapalia@mit.edu
+ * Copyright 2020 The Ambitious Folks of the MRG
+ */
+
+// NOLINTNEXTLINE
+#include <chrono>
+#include <fstream>
+#include <iostream>
+// NOLINTNEXTLINE
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/inference/Symbol.h>
+
+#include <thread>
+
+#include "tonioviz/GtsamUtils.h"
+#include "tonioviz/Visualizer.h"
+
+// Forwards declarations.
+gtsam::Values GetDummyGtsamValues(
+    const std::vector<std::vector<gtsam::Symbol>> pose_symbols,
+    const std::map<int, gtsam::Symbol> landmark_symbols, const bool is3d);
+gtsam::Pose2 GetPose2(size_t robot, size_t time);
+gtsam::Pose3 GetPose3(size_t robot, size_t time);
+std::vector<gtsam::Point2> GetPoint2Vector(size_t num_landmarks);
+std::vector<gtsam::Point3> GetPoint3Vector(size_t num_landmarks);
+
+std::array<char, 12> robot_chars = {'a', 'b', 'c', 'd', 'e', 'f',
+                                    'g', 'h', 'j', 'k', 'l', 'm'};
+float k = 0.1;
+
+inline char get_robot_char(int rob_id) { return robot_chars[rob_id]; }
+inline gtsam::Symbol get_pose_symbol(size_t rob_id, size_t pose_id) {
+  return gtsam::Symbol(get_robot_char(rob_id), pose_id);
+}
+inline gtsam::Symbol get_landmark_symbol(size_t land_id) {
+  return gtsam::Symbol('L', land_id);
+}
+
+using LandmarkPair = std::pair<int, gtsam::Symbol>;
+
+int main() {
+  size_t num_poses = 1000;
+  size_t num_landmarks = 10;
+  size_t num_robots = 5;
+  bool is3d = true;
+  bool animation = true;
+  size_t ms_wait = 10;
+
+  // make 2d array of pose symbols
+  std::vector<std::vector<gtsam::Symbol>> pose_symbols(num_robots);
+  for (size_t robot = 0; robot < num_robots; robot++) {
+    for (size_t time = 0; time < num_poses; time++) {
+      pose_symbols[robot].push_back(get_pose_symbol(robot, time));
+    }
+  }
+
+  // make map of landmark symbols
+  std::map<int, gtsam::Symbol> landmark_symbols;
+  LandmarkPair land_pair;
+  for (size_t i = 0; i < num_landmarks; i++) {
+    size_t land_id = 3 * i;
+    land_pair = LandmarkPair(land_id, get_landmark_symbol(land_id));
+    landmark_symbols.insert(land_pair);
+  }
+
+  // fill up trajectories and landmarks for each symbol
+  gtsam::Values values;
+  values = GetDummyGtsamValues(pose_symbols, landmark_symbols, is3d);
+
+  // visualize trajectories and landmarks
+  mrg::VisualizeGtsamEstimates(values, pose_symbols, landmark_symbols, is3d,
+                               animation, ms_wait);
+}
+
+/* ************************************************************************** */
+gtsam::Values GetDummyGtsamValues(
+    const std::vector<std::vector<gtsam::Symbol>> pose_symbols,
+    const std::map<int, gtsam::Symbol> landmark_symbols, const bool is3d) {
+  gtsam::Values values;
+  gtsam::Symbol sym;
+
+  // fill up poses
+  for (size_t robot = 0; robot < pose_symbols.size(); robot++) {
+    for (size_t time = 0; time < pose_symbols[robot].size(); time++) {
+      sym = pose_symbols[robot][time];
+      if (is3d) {
+        values.insert(sym, GetPose3(robot, time));
+      } else {
+        values.insert(sym, GetPose2(robot, time));
+      }
+    }
+  }
+
+  // fill up landmarks
+  if (is3d) {
+    std::vector<gtsam::Point3> landmarks =
+        GetPoint3Vector(landmark_symbols.size());
+
+    uint8_t cnt = 0;
+    for (std::map<int, gtsam::Symbol>::const_iterator it =
+             landmark_symbols.begin();
+         it != landmark_symbols.end(); it++) {
+      sym = it->second;
+      values.insert(sym, landmarks[cnt]);
+      cnt++;
+    }
+  } else {
+    std::vector<gtsam::Point2> landmarks =
+        GetPoint2Vector(landmark_symbols.size());
+
+    uint8_t cnt = 0;
+    for (std::map<int, gtsam::Symbol>::const_iterator it =
+             landmark_symbols.begin();
+         it != landmark_symbols.end(); it++) {
+      sym = it->second;
+      values.insert(sym, landmarks[cnt]);
+      cnt++;
+    }
+  }
+
+  return values;
+}
+
+gtsam::Pose2 GetPose2(size_t robot, size_t time) {
+  float x = 2 * robot + 2 * std::sin(robot * M_PI + time * k);  // x
+  float y = 2 * std::sin(robot * M_PI + time * k) *
+            std::cos(robot * M_PI + time * k);  // y
+  float rad = (time * k);                       // radians
+
+  return gtsam::Pose2(x, y, rad);
+}
+
+gtsam::Pose3 GetPose3(size_t robot, size_t time) {
+  float x = 2 * robot + 2 * std::sin(robot * M_PI + time * k);  // x
+  float y = 2 * std::sin(robot * M_PI + time * k) *
+            std::cos(robot * M_PI + time * k);  // y
+  float z = std::sin(robot * M_PI + 2*time * k);  // z
+  float yaw = (time * k);                       // yaw
+  float pitch = (time * k);                     // pitch
+  float roll = (time * k);                      // roll
+
+  return gtsam::Pose3(gtsam::Rot3::Yaw(yaw), gtsam::Point3(x, y, z));
+}
+
+std::vector<gtsam::Point2> GetPoint2Vector(size_t num_landmarks) {
+  // set up randomization as per links
+  // https://stackoverflow.com/questions/686353/random-float-number-generation
+  // https://diego.assencio.com/?index=6890b8c50169ef45b74db135063c227c
+  std::random_device rnd_dev;
+  std::mt19937 generator{rnd_dev()};  // Generates random integers
+  std::uniform_real_distribution<> distribution{-5, 5};
+
+  // randomly fill vectors
+  std::vector<float> x_locs(num_landmarks);
+  std::vector<float> y_locs(num_landmarks);
+  for (size_t i = 0; i < num_landmarks; i++) {
+    x_locs[i] = distribution(generator);
+    y_locs[i] = distribution(generator);
+  }
+
+  // fill landmarks vector
+  std::vector<gtsam::Point2> landmarks;
+  for (size_t i = 0; i < num_landmarks; i++) {
+    landmarks.emplace_back(gtsam::Point2(x_locs[i], y_locs[i]));
+  }
+
+  return landmarks;
+}
+
+std::vector<gtsam::Point3> GetPoint3Vector(size_t num_landmarks) {
+  // set up randomization as per links
+  // https://stackoverflow.com/questions/686353/random-float-number-generation
+  // https://diego.assencio.com/?index=6890b8c50169ef45b74db135063c227c
+  std::random_device rnd_dev;
+  std::mt19937 generator{rnd_dev()};  // Generates random integers
+  std::uniform_real_distribution<> distribution{-5, 5};
+
+  // randomly fill vectors
+  std::vector<float> x_locs(num_landmarks);
+  std::vector<float> y_locs(num_landmarks);
+  std::vector<float> z_locs(num_landmarks);
+  for (size_t i = 0; i < num_landmarks; i++) {
+    x_locs[i] = distribution(generator);
+    y_locs[i] = distribution(generator);
+    z_locs[i] = distribution(generator);
+  }
+
+  // fill landmarks vector
+  std::vector<gtsam::Point3> landmarks;
+  for (size_t i = 0; i < num_landmarks; i++) {
+    landmarks.emplace_back(gtsam::Point3(x_locs[i], y_locs[i], z_locs[i]));
+  }
+
+  return landmarks;
+}

--- a/examples/LandmarkExample.cpp
+++ b/examples/LandmarkExample.cpp
@@ -62,9 +62,9 @@ void DataPlaybackLoop(mrg::Visualizer *viz) {
   }
 
   // fill landmarks vector
-  std::vector<Eigen::Vector3d> landmarks;
+  std::vector<mrg::VizLandmark> landmarks;
   for (size_t i = 0; i < num_landmarks; i++) {
-    landmarks.emplace_back(Eigen::Vector3d(x_locs[i], y_locs[i], z_locs[i]));
+    landmarks.emplace_back(mrg::VizLandmark(x_locs[i], y_locs[i], z_locs[i]));
   }
 
   // add landmarks to visualizer

--- a/include/tonioviz/GtsamUtils.h
+++ b/include/tonioviz/GtsamUtils.h
@@ -2,24 +2,95 @@
  * @file GtsamUtils.cpp
  * @brief Utility functions for interacting with GTSAM objects.
  * @author Tonio Teran, teran@mit.edu
+ * @author Alan Papalia, apapalia@mit.edu
  * Copyright 2020 The Ambitious Folks of the MRG
  */
 
 #ifndef TONIOVIZ_GTSAMUTILS_H_
 #define TONIOVIZ_GTSAMUTILS_H_
 
-#include <string>
-#include <vector>
-
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/nonlinear/ISAM2.h>
 #include <gtsam/nonlinear/Values.h>
 #include <gtsam/slam/dataset.h>
-#include <gtsam/slam/dataset.h>
-#include <gtsam/nonlinear/ISAM2.h>
+
+#include <string>
+#include <vector>
 
 #include "tonioviz/DataUtils.h"
 #include "tonioviz/Visualizer.h"
 
 namespace mrg {
+
+/**
+ * @brief Takes GTSAM pose object and returns as VizPose object
+ *
+ * @param pose3     GTSAM pose to convert to matrix form
+ * @param length    length of the pose axes
+ * @param width     width of the pose axes
+ * @return VizPose
+ */
+inline VizPose GetVizPose(const gtsam::Pose3 pose3, const double length = 0.1,
+                          const double width = 2.0);
+
+/**
+ * @brief Takes GTSAM pose object and returns as VizPose object
+ *
+ * @param pose2     GTSAM pose to convert to matrix form
+ * @param length    length of the pose axes
+ * @param width     width of the pose axes
+ * @return VizPose
+ */
+inline VizPose GetVizPose(const gtsam::Pose2 pose2, const double length = 0.1,
+                          const double width = 2.0);
+
+inline VizLandmark GetVizLandmark(const gtsam::Point2 landmark) {
+  VizLandmark v_landmark = Eigen::Vector3d::Zero();
+  v_landmark.block(0, 0, 2, 1) = landmark.matrix();
+  return v_landmark;
+}
+
+/**
+ * @brief Convert from gtsam::Point3 to VizLandmark
+ *
+ * @param landmark
+ * @return VizLandmark
+ */
+inline VizLandmark GetVizLandmark(const gtsam::Point3 landmark) {
+  VizLandmark v_landmark = landmark.matrix();
+  return v_landmark;
+}
+
+/**
+ * @brief Convert from vector of gtsam::Point2 to vector of VizLandmarks
+ *
+ * @param landmarks
+ * @return std::vector<VizLandmark>
+ */
+inline std::vector<VizLandmark> GetVizLandmarks(
+    const std::vector<gtsam::Point2> landmarks) {
+  std::vector<VizLandmark> v_landmarks;
+  for (size_t i = 0; i < landmarks.size(); i++) {
+    v_landmarks.emplace_back(GetVizLandmark(landmarks[i]));
+  }
+  return v_landmarks;
+}
+
+
+/**
+ * @brief Convert from vector of gtsam::Point3 to vector of VizLandmarks
+ *
+ * @param landmarks
+ * @return std::vector<VizLandmark>
+ */
+inline std::vector<VizLandmark> GetVizLandmarks(
+    const std::vector<gtsam::Point3> landmarks) {
+  std::vector<VizLandmark> v_landmarks;
+  for (size_t i = 0; i < landmarks.size(); i++) {
+    v_landmarks.emplace_back(GetVizLandmark(landmarks[i]));
+  }
+  return v_landmarks;
+}
 
 /**
  * @brief Builds vector of visualization poses to pass directly onto visualizer.
@@ -39,14 +110,44 @@ std::vector<VizPose> GetVizPoses(const gtsam::Values& values,
                                  const bool is3d = true);
 
 /**
- * @brief Writes current values of variables inside isam object to a g2o file
- * and then visualizes the contents of the g2o file
+ * @brief Runs the visualizer in a separate thread. Constructs the visualizer
+ * and then offloads the data loading to GtsamDataLoop
  *
- * @param isam the isam object to visualize all current estimates of
- * @param output_file the filepath where the saved g2o representation of the
- * estimates will be kept
+ * @param vals                  the estimates of the poses and landmarks
+ * @param pose_symbols          GTSAM symbols for all poses
+ * @param landmark_symbols      GTSAM symbols for all landmarks
+ * @param is3d                  whether the data is in 2D or 3D
+ * @param animation             whether to play as animation
+ * @param ms_wait               how long to pause (in ms) between frames
+ *
+ * NOTE: this assumes that all information provided is either a sequence of
+ * poses or a vector of landmarks.
+ *
  */
-void visualize_isam_estimates(gtsam::ISAM2 isam, std::string output_file);
+void VisualizeGtsamEstimates(
+    const gtsam::Values vals,
+    std::vector<std::vector<gtsam::Symbol>> pose_symbols,
+    std::map<int, gtsam::Symbol> landmark_symbols, const bool is3d = true,
+    const bool animation = true, const size_t ms_wait = 50);
+
+/**
+ * @brief Reads data in gtsam estimate and plays poses inside of visualizer. Can
+ * be run as an animation (incrementally displaying poses) or just to show all
+ * trajectories at once
+ *
+ * @param viz                   Visualization window
+ * @param curr_estimate         the estimates of the poses and landmarks
+ * @param pose_symbols          GTSAM symbols for all poses
+ * @param landmark_symbols      GTSAM symbols for all landmarks
+ * @param is3d                  whether the data is in 2D or 3D
+ * @param animation             whether to play as animation
+ * @param ms_wait               how long to pause between frames
+ */
+static void GtsamDataLoop(mrg::Visualizer* viz, gtsam::Values curr_estimate,
+                          std::vector<std::vector<gtsam::Symbol>> pose_symbols,
+                          std::map<int, gtsam::Symbol> landmark_symbols,
+                          const bool is3d, const bool animation,
+                          const size_t ms_wait);
 
 }  // namespace mrg
 

--- a/include/tonioviz/Visualizer.h
+++ b/include/tonioviz/Visualizer.h
@@ -29,8 +29,9 @@ typedef std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Matrix4d>>
 /// 3D Pose with axes length (1st double) and line width (2nd double) for viz.
 typedef std::tuple<Eigen::Matrix4d, double, double> VizPose;
 
-/// 3D Pose with axes length (1st double) and line width (2nd double) for viz.
+/// 3D Position of landmark
 typedef Eigen::Vector3d VizLandmark;
+
 // typedef std::vector<VizPose, Eigen::aligned_allocator<Eigen::Matrix4d>>
 //     VizPoseVec;
 
@@ -217,8 +218,24 @@ class Visualizer {
    */
   void DrawTrajectory(const std::vector<VizPose>& trajectory) const;
 
-  // TODO (alan) finish this function
-  void DrawLandmarks(const std::vector<VizLandmark>& landmarks) const;
+  inline void DrawLandmarks(const std::vector<VizLandmark>& landmarks) const{
+  // Draw all landmarks
+  glColor3f(1.0f, 0.0, 0.0);
+  double rad = 0.25;
+  if (p_.landtype == LandmarkDrawType::kCross) {
+    for (const VizLandmark& vl : landmarks) {
+      pangolin::glDrawCross(vl, rad);
+    }
+  } else if (p_.landtype == LandmarkDrawType::kPoint) {
+    pangolin::glDrawPoints(landmarks);
+  } else {
+    std::cerr << "Attempted landmark visualization is not supported"
+              << std::endl;
+    assert(false);
+  }
+
+  glLineWidth(1.0);
+  }
 
   inline void DrawLandmarks() const { DrawLandmarks(landmarks_); }
 

--- a/src/Visualizer.cpp
+++ b/src/Visualizer.cpp
@@ -243,25 +243,6 @@ void Visualizer::DrawTrajectory(const std::vector<VizPose>& trajectory) const {
   glColor3f(1.0, 1.0, 1.0);
 }
 
-void Visualizer::DrawLandmarks(
-    const std::vector<VizLandmark>& landmarks) const {
-  // Draw all landmarks
-  glColor3f(1.0f, 0.0, 0.0);
-  double rad = 0.25;
-  if (p_.landtype == LandmarkDrawType::kCross) {
-    for (const VizLandmark& vl : landmarks) {
-      pangolin::glDrawCross(vl, rad);
-    }
-  } else if (p_.landtype == LandmarkDrawType::kPoint) {
-    pangolin::glDrawPoints(landmarks);
-  } else {
-    std::cerr << "Attempted landmark visualization is not supported"
-              << std::endl;
-    assert(false);
-  }
-
-  glLineWidth(1.0);
-}
 
 /* *************************************************************************  */
 void Visualizer::AddImage(const cv::Mat& img) {


### PR DESCRIPTION
Added functionality to visualize 2d/3d trajectories and 2d/3d landmarks from GTSAM. Assumes that trajectories are referenced by 2d vector of symbols and landmarks are referenced by 1d vector of symbols. Examples of usage can be seen in the examples subdirectory.