### PR TITLE
added functionality to force-quit the visualizer by pressing the 'q' key

### DIFF
--- a/examples/GtsamExample2.cpp
+++ b/examples/GtsamExample2.cpp
@@ -48,7 +48,7 @@ int main() {
   size_t num_robots = 5;
   bool is3d = true;
   bool animation = true;
-  size_t ms_wait = 10;
+  size_t ms_wait = 20;
 
   // make 2d array of pose symbols
   std::vector<std::vector<gtsam::Symbol>> pose_symbols(num_robots);

--- a/include/tonioviz/Visualizer.h
+++ b/include/tonioviz/Visualizer.h
@@ -204,6 +204,11 @@ class Visualizer {
     }
   }
 
+  /**
+   * @brief Allows to check if the visualizer has been told to force quit
+   */
+  inline bool HasForcedQuit() {return forced_quit_;}
+
  private:
   /**
    * @brief Renders the trajectory as a sequence of poses.
@@ -218,28 +223,32 @@ class Visualizer {
    */
   void DrawTrajectory(const std::vector<VizPose>& trajectory) const;
 
-  inline void DrawLandmarks(const std::vector<VizLandmark>& landmarks) const{
-  // Draw all landmarks
-  glColor3f(1.0f, 0.0, 0.0);
-  double rad = 0.25;
-  if (p_.landtype == LandmarkDrawType::kCross) {
-    for (const VizLandmark& vl : landmarks) {
-      pangolin::glDrawCross(vl, rad);
+  inline void DrawLandmarks(const std::vector<VizLandmark>& landmarks) const {
+    // Draw all landmarks
+    glColor3f(1.0f, 0.0, 0.0);
+    double rad = 0.25;
+    if (p_.landtype == LandmarkDrawType::kCross) {
+      for (const VizLandmark& vl : landmarks) {
+        pangolin::glDrawCross(vl, rad);
+      }
+    } else if (p_.landtype == LandmarkDrawType::kPoint) {
+      pangolin::glDrawPoints(landmarks);
+    } else {
+      std::cerr << "Attempted landmark visualization is not supported"
+                << std::endl;
+      assert(false);
     }
-  } else if (p_.landtype == LandmarkDrawType::kPoint) {
-    pangolin::glDrawPoints(landmarks);
-  } else {
-    std::cerr << "Attempted landmark visualization is not supported"
-              << std::endl;
-    assert(false);
-  }
 
-  glLineWidth(1.0);
+    glLineWidth(1.0);
   }
 
   inline void DrawLandmarks() const { DrawLandmarks(landmarks_); }
 
+
   VisualizerParams p_;  ///< Internal copy of the configuration parameters.
+  const std::string _window_name =
+      "mrg official viewer";  // name of the visualizer window
+  bool forced_quit_ = false;
 
   // Manually-modifiable variables.
   std::vector<std::vector<VizPose>>

--- a/src/GtsamUtils.cpp
+++ b/src/GtsamUtils.cpp
@@ -100,6 +100,9 @@ static void GtsamDataLoop(mrg::Visualizer *viz, gtsam::Values curr_estimate,
   // Add poses to visualizer
   for (size_t timestep = 0; timestep < num_timesteps; timestep++) {
     for (size_t robot = 0; robot < num_robots; robot++) {
+      if (viz->HasForcedQuit()){
+        return;
+      }
       // don't try to add poses that don't exist
       if (timestep >= pose_symbols[robot].size()) {
         continue;

--- a/src/Visualizer.cpp
+++ b/src/Visualizer.cpp
@@ -31,7 +31,7 @@ Visualizer::~Visualizer() {}
 
 void Visualizer::RenderWorld() {
   std::cout << "Starting the visualization thread." << std::endl;
-  pangolin::CreateWindowAndBind("mrg official viewer", p_.w, p_.h);
+  pangolin::CreateWindowAndBind(_window_name, p_.w, p_.h);
   glEnable(GL_DEPTH_TEST);
 
   // TODO(tonioteran) Figure out what the rest of the hardcoded params are, and
@@ -68,6 +68,11 @@ void Visualizer::RenderWorld() {
     } else if (p_.kftype == KeyframeDrawType::kTriad) {
       p_.kftype = KeyframeDrawType::kFrustum;
     }
+  });
+  pangolin::RegisterKeyPressCallback('q', [&]() {
+    pangolin::QuitAll();
+    pangolin::DestroyWindow(_window_name);
+    forced_quit_ = true;
   });
 
   bool show_manual = true;


### PR DESCRIPTION
Any user should now be able to press the 'q' key during visualization to elegantly kill the visualizer early. This is useful for animations being called from other programs where we may want to kill the animation but continue running the program.